### PR TITLE
testing refactor of auth

### DIFF
--- a/src/action/auth.js
+++ b/src/action/auth.js
@@ -1,7 +1,7 @@
 import superagent from 'superagent';
 import * as routes from '../routes';
 
-export const set = token => ({
+export const tokenSet = token => ({
   type: 'TOKEN_SET',
   payload: token,
 });
@@ -21,7 +21,7 @@ export const signupRequest = user => (store) => {
       document.cookie = `rims-cookie=${bareToken}`;
       document.cookie = `expires=${expire.toUTCString()};`;
       console.log(document.cookie);
-      return store.dispatch(set(response.text));
+      return store.dispatch(tokenSet(response.text));
     });
 };
 
@@ -29,12 +29,17 @@ export const loginRequest = user => (store) => {
   return superagent.get(`${API_URL}${routes.LOGIN_BACKEND}`)
     .auth(user.username, user.password)
     .then((response) => {
-      const bareToken = JSON.parse(response.text).token;
+      console.log('response:');
+      console.log(response);
+      const bareToken = response.body.token;
+      console.log('bareToken');
+      console.log(bareToken);
       const expire = new Date();
       expire.setHours(expire.getHours() + 4);
       document.cookie = `rims-cookie=${bareToken}`;
       document.cookie = `expires=${expire.toUTCString()};`;
       console.log(document.cookie);
-      return store.dispatch(set(response.text));
+      // set isAdmin to determine menu availability and dbQueries etc
+      return store.dispatch(tokenSet([{ token: response.body.token, isAdmin: response.body.isAdmin }]));
     });
 };

--- a/src/components/landing/landing.js
+++ b/src/components/landing/landing.js
@@ -16,9 +16,9 @@ class Landing extends React.Component {
   constructor(props) {
     super(props);
     // setup store with needed DB data
-    this.props.pGetUsers();
-    this.props.pGetSubAssy();
-    this.props.pGetParts();
+    // this.props.pGetUsers();
+    // this.props.pGetSubAssy();
+    // this.props.pGetParts();
   }
   handleLogin = (user) => {
     return this.props.pDoLogin(user)

--- a/src/reducer/main-reducer.js
+++ b/src/reducer/main-reducer.js
@@ -4,4 +4,6 @@ import users from './users-reducer';
 import subAssy from './sub-assy-reducer';
 import parts from './parts-reducer';
 
-export default combineReducers({ token, users, subAssy, parts });
+export default combineReducers({
+  token, users, subAssy, parts,
+});

--- a/src/reducer/token-reducer.js
+++ b/src/reducer/token-reducer.js
@@ -19,6 +19,8 @@ function findMeTheToken(strToFind) {
 const initialState = findMeTheToken('rims-cookie');
 
 export default (state = initialState, { type, payload }) => {
+  console.log('token payload');
+  console.log(payload);
   switch (type) {
     case 'TOKEN_SET':
       // Token was being assigned as the DOM in a string...


### PR DESCRIPTION
@tnorth93 @jlhiskey 

See notes in this back-end PR:
https://github.com/lets-go-geronimo/readyIMS-back-end/pull/13

The only change that will probably stick in this PR is the removal of DB query on the login screen. 

These changes were just me testing with the back-end today. It revealed some needed auth refactoring to handle rendering certain components/features, based on if the user isAdmin: true or isAdmin: false. This will come from a Bearerauth API hit / response. Additions to the store/actions/reducers will likely be needed. 

As noted in the referenced PR, I will continue working on this tomorrow morning. You can leave all the open PRs open for now.

Ben