### PR TITLE
finished handling for token refresh / reject

### DIFF
--- a/src/action/auth.js
+++ b/src/action/auth.js
@@ -37,3 +37,46 @@ export const loginRequest = user => (store) => {
       return store.dispatch(tokenSet([{ token: response.body.token, isAdmin: response.body.isAdmin }]));
     });
 };
+
+// handle using token post refresh
+function findMeTheToken(strToFind) {
+  const cookies = document.cookie.split('; ');
+  let rimsToken = null;
+  let prop = null; // eslint-disable-line no-unused-vars
+  let key = null;
+  for (let i = 0; i <= cookies.length - 1; i++) {
+    if (cookies[i].includes(strToFind)) {
+      rimsToken = cookies[i];
+    }
+  }
+  if (rimsToken !== null) {
+    prop = rimsToken.split('=')[0]; // eslint-disable-line prefer-destructuring
+    key = rimsToken.split('=')[1]; // eslint-disable-line prefer-destructuring
+  }
+  return key || null;
+}
+
+export const tokenRefreshOrReject = user => (store) => {
+  const token = findMeTheToken('rims-cookie');
+  return superagent.get(`${API_URL}${routes.TOKEN_AUTH_BACKEND}`)
+    .set('Authorization', `Bearer ${token}`)
+    .send()
+    .then((response) => {
+      const returnObject = {};
+      returnObject.token = response.body.token;
+      returnObject.isAdmin = response.body.isAdmin;
+      const expire = new Date();
+      expire.setHours(expire.getHours() + 4);
+      document.cookie = `rims-cookie=${returnObject.token}`;
+      document.cookie = `expires=${expire.toUTCString()};`;
+      return store.dispatch(tokenSet([{
+        token: returnObject.token,
+        isAdmin: returnObject.isAdmin,
+      }]));
+    })
+    .catch((error) => {
+      console.log('tokenRefreshOrReject action error:');
+      console.log(error.response);
+      return error.response;
+    });
+};

--- a/src/components/dashboard/dashboard.js
+++ b/src/components/dashboard/dashboard.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import defaultLogo from '../../../assets/defaultLogo.png';
 import SubAssembliesTable from '../sub-assemblies-table/sub-assemblies-table';
 import * as dataActions from '../../action/data';
-import * as authActions from "../../action/auth";
 import NavUi from '../nav-ui/nav-ui';
 import UnassociatedPartsTable from '../unassociated-parts-table/unassociated-parts-table';
 import SiteBranding from '../site-branding/site-branding';

--- a/src/reducer/token-reducer.js
+++ b/src/reducer/token-reducer.js
@@ -1,44 +1,4 @@
-import superagent from 'superagent';
-import * as routes from '../routes';
-
-function reValidateUser(token) {
-  return superagent.get(`${API_URL}${routes.TOKEN_AUTH_BACKEND}`)
-    .set('Authorization', `Bearer ${token}`)
-    .send()
-    .then((response) => {
-      const returnObject = {};
-      returnObject.token = response.body.token;
-      returnObject.isAdmin = response.body.isAdmin;
-      const expire = new Date();
-      expire.setHours(expire.getHours() + 4);
-      document.cookie = `rims-cookie=${returnObject.token}`;
-      document.cookie = `expires=${expire.toUTCString()};`;
-      return returnObject;
-    })
-    .catch(console.error);
-}
-
-// handle using token post refresh
-function findMeTheToken(strToFind) {
-  const cookies = document.cookie.split('; ');
-  let rimsToken = null;
-  let prop = null; // eslint-disable-line no-unused-vars
-  let key = null;
-  for (let i = 0; i <= cookies.length - 1; i++) {
-    if (cookies[i].includes(strToFind)) {
-      rimsToken = cookies[i];
-    }
-  }
-  if (rimsToken !== null) {
-    prop = rimsToken.split('=')[0]; // eslint-disable-line prefer-destructuring
-    key = rimsToken.split('=')[1]; // eslint-disable-line prefer-destructuring
-  }
-  return key ? reValidateUser(key) : null;
-}
-
-const initialState = findMeTheToken('rims-cookie');
-// const token = findMeTheToken('rims-cookie');
-// const initialState = null;
+const initialState = null;
 
 export default (state = initialState, { type, payload }) => {
   switch (type) {


### PR DESCRIPTION
@tnorth93 @jlhiskey 

Finally solved what was happening with the issues listed on this PR:
https://github.com/lets-go-geronimo/readyIMS-front-end/pull/15

These new changes now successfully update the token redux store as well as the cookie. This is also handled upon refresh. You can now click refresh on any page and you will be forced to be re authenticated but you will end up back at that page. This is due to the token checking being moved from the reducer to the auth-redirect component.

There will be additional changes in the pipeline to better manage the store to properly have a token state and an "account state". For now, this is a big improvement to security and how the account is being sent back to the front-end.

Ben